### PR TITLE
fix README to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-slack-hook2 = "0.8"
+slack-hook2 = "0.10"
 ```
 
 Add the crate to your existing project:
@@ -25,7 +25,8 @@ Add the crate to your existing project:
 ```rust,no_run
 use slack_hook2::{Slack, PayloadBuilder};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let slack = Slack::new("https://hooks.slack.com/services/abc/123/45z").unwrap();
     let p = PayloadBuilder::new()
       .text("test message")
@@ -35,7 +36,7 @@ fn main() {
       .build()
       .unwrap();
 
-    let res = slack.send(&p);
+    let res = slack.send(&p).await;
     match res {
         Ok(()) => println!("ok"),
         Err(x) => println!("ERR: {:?}",x)


### PR DESCRIPTION
I just tried to this library.

slack-hook2 v0.8 is not exist on cargo.
send changed to return future. So it need to be async function.